### PR TITLE
moving dcfglib into pkg as dcfg, also fixing tests

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/drud/dcfg/dcfglib"
+	"github.com/drud/dcfg/pkg/dcfg"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +45,7 @@ var runCmd = &cobra.Command{
 			log.Fatalln("Could not read config file:", err)
 		}
 
-		groups, err := dcfglib.GetTaskSetList(fileBytes)
+		groups, err := dcfg.GetTaskSetList(fileBytes)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/dcfg_test.go
+++ b/dcfg_test.go
@@ -62,10 +62,12 @@ func TestRunOptions(t *testing.T) {
 	cmdCFG := `
 - name: create
   tasks:
-  - cmd: touch testdcfg.txt
+  - action: command
+    cmd: touch testdcfg.txt
 - name: delete
   tasks:
-  - cmd: rm testdcfg.txt
+  - action: command
+    cmd: rm testdcfg.txt
     `
 
 	tmpFile := getTempFile(cmdCFG)

--- a/pkg/dcfg/tasks.go
+++ b/pkg/dcfg/tasks.go
@@ -1,6 +1,6 @@
-// Package dcfglib groups.go - The TaskSet and TaskSetList types represent the blocks of commands
+// Package dcfg groups.go - The TaskSet and TaskSetList types represent the blocks of commands
 // contained in your drud.yaml(e.g. the install and uninstall examples from the readne).
-package dcfglib
+package dcfg
 
 import (
 	"bytes"

--- a/pkg/dcfg/utils.go
+++ b/pkg/dcfg/utils.go
@@ -1,4 +1,4 @@
-package dcfglib
+package dcfg
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Tanner changed this https://github.com/drud/dcfg/pull/5/files#diff-e540b5efa4ce165399814e0fc4016fa4L9 which allowed me to keep the library on the root level and still reference it as dcfg.

But because he doesn't like that and the package should be in the `pkg` directory anyway I just went ahed and moved it.